### PR TITLE
게시물 관련 기능 개발, 좋아요 기능(게시물, 댓글) 개발

### DIFF
--- a/src/main/java/com/Sucat/domain/board/controller/BoardController.java
+++ b/src/main/java/com/Sucat/domain/board/controller/BoardController.java
@@ -53,8 +53,8 @@ public class BoardController {
 
     /* 게시글 단일 조회 */
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<Object>> getBoard(@PathVariable Long id) {
-        BoardDetailResponse board = boardService.getBoard(id);
+    public ResponseEntity<ApiResponse<Object>> getBoard(@PathVariable Long id, HttpServletRequest request) {
+        BoardDetailResponse board = boardService.getBoard(id, request);
         return ApiResponse.onSuccess(SuccessCode._OK, board);
     }
 

--- a/src/main/java/com/Sucat/domain/board/dto/BoardDto.java
+++ b/src/main/java/com/Sucat/domain/board/dto/BoardDto.java
@@ -112,9 +112,11 @@ public class BoardDto {
             int commentCount,
 //            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
             LocalDateTime createdAt,
-             List<CommentResponseWithBoard> commentList
+             List<CommentResponseWithBoard> commentList,
+            boolean isLikedByUser, // 현재 사용자가 좋아요를 누른 게시글인지 체크,
+            boolean isScrapByUser // 현재 사용자가 스크랩한 게시글인지 체크
     ) {
-        public static BoardDetailResponse of(Board board, List<CommentResponseWithBoard> commentList) {
+        public static BoardDetailResponse of(Board board, List<CommentResponseWithBoard> commentList, Boolean isLikedByUser, boolean isScrapByUser) {
             List<String> imageNames = board.getImageList().stream()
                     .map(Image::getImageName)
                     .toList();
@@ -129,6 +131,8 @@ public class BoardDto {
                     .commentCount(board.getCommentCount())
                     .createdAt(board.getCreatedAt())
                     .commentList(commentList)
+                    .isLikedByUser(isLikedByUser)
+                    .isScrapByUser(isScrapByUser)
                     .build();
         }
     }

--- a/src/main/java/com/Sucat/domain/board/model/Board.java
+++ b/src/main/java/com/Sucat/domain/board/model/Board.java
@@ -2,6 +2,7 @@ package com.Sucat.domain.board.model;
 
 import com.Sucat.domain.comment.domain.Comment;
 import com.Sucat.domain.image.model.Image;
+import com.Sucat.domain.like.model.BoardLike;
 import com.Sucat.domain.scrap.model.Scrap;
 import com.Sucat.domain.user.model.User;
 import com.Sucat.global.common.dao.BaseEntity;
@@ -58,6 +59,9 @@ public class Board extends BaseEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<BoardLike> likeList = new ArrayList<>();
+
     @Builder
     public Board(String userNickname, String title, String content, BoardCategory category) {
         this.userNickname = userNickname;
@@ -102,8 +106,18 @@ public class Board extends BaseEntity {
         this.scrapCount++;
     }
 
+    public void addLike(BoardLike boardLike) {
+        likeList.add(boardLike);
+        this.likeCount++;
+    }
+
+
     public void decrementScrapCount() {
         this.scrapCount--;
+    }
+
+    public void decrementLikeCount() {
+        this.likeCount--;
     }
 
     public void addComment(Comment comment) {

--- a/src/main/java/com/Sucat/domain/board/model/Board.java
+++ b/src/main/java/com/Sucat/domain/board/model/Board.java
@@ -56,7 +56,7 @@ public class Board extends BaseEntity {
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Scrap> scrapList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/src/main/java/com/Sucat/domain/board/service/BoardService.java
+++ b/src/main/java/com/Sucat/domain/board/service/BoardService.java
@@ -135,6 +135,7 @@ public class BoardService {
     /* 게시물 단일 조회 메서드 */
     public BoardDetailResponse getBoard(Long id) {
         Board board = findBoardById(id);
+        Long userId = board.getUser().getId();
         List<CommentResponseWithBoard> commentList = board.getCommentList().stream()
                 .map(CommentResponseWithBoard::of)
                 .toList();

--- a/src/main/java/com/Sucat/domain/comment/domain/Comment.java
+++ b/src/main/java/com/Sucat/domain/comment/domain/Comment.java
@@ -32,7 +32,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<CommentLike> likeList = new ArrayList<>();
 
     private String content;

--- a/src/main/java/com/Sucat/domain/comment/domain/Comment.java
+++ b/src/main/java/com/Sucat/domain/comment/domain/Comment.java
@@ -31,13 +31,15 @@ public class Comment extends BaseEntity {
     private String content;
     private int likeCount;
     private int commentCount;
+    private boolean checkWriter;
 
     @Builder
-    public Comment(Board board, User user, String content) {
+    public Comment(Board board, User user, String content, boolean checkWriter) {
         this.board = board;
         this.user = user;
         this.content = content;
         this.likeCount = 0;
         this.commentCount = 0;
+        this.checkWriter = checkWriter;
     }
 }

--- a/src/main/java/com/Sucat/domain/comment/domain/Comment.java
+++ b/src/main/java/com/Sucat/domain/comment/domain/Comment.java
@@ -1,6 +1,7 @@
 package com.Sucat.domain.comment.domain;
 
 import com.Sucat.domain.board.model.Board;
+import com.Sucat.domain.like.model.CommentLike;
 import com.Sucat.domain.user.model.User;
 import com.Sucat.global.common.dao.BaseEntity;
 import jakarta.persistence.*;
@@ -8,6 +9,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 
@@ -28,10 +32,13 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CommentLike> likeList = new ArrayList<>();
+
     private String content;
     private int likeCount;
     private int commentCount;
-    private boolean checkWriter;
+    private boolean checkWriter; // 게시글 작성자가 작성한 댓글인지
 
     @Builder
     public Comment(Board board, User user, String content, boolean checkWriter) {
@@ -41,5 +48,15 @@ public class Comment extends BaseEntity {
         this.likeCount = 0;
         this.commentCount = 0;
         this.checkWriter = checkWriter;
+    }
+
+    /* Using Method */
+    public void addLike(CommentLike commentLike) {
+        likeList.add(commentLike);
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        this.likeCount--;
     }
 }

--- a/src/main/java/com/Sucat/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/Sucat/domain/comment/dto/CommentDto.java
@@ -33,7 +33,8 @@ public class CommentDto {
             String content,
             int likeCount,
             int commentCount,
-            LocalDateTime createAt
+            LocalDateTime createAt,
+            boolean checkWriter
     ) {
         public static CommentResponseWithBoard of(Comment comment) {
             User user = comment.getUser();
@@ -47,6 +48,7 @@ public class CommentDto {
                     .likeCount(comment.getLikeCount())
                     .commentCount(comment.getCommentCount())
                     .createAt(comment.getCreatedAt())
+                    .checkWriter(comment.isCheckWriter())
                     .build();
         }
     }

--- a/src/main/java/com/Sucat/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/Sucat/domain/comment/dto/CommentDto.java
@@ -34,11 +34,15 @@ public class CommentDto {
             int likeCount,
             int commentCount,
             LocalDateTime createAt,
-            boolean checkWriter
+            boolean checkWriter, // 게시글 작성자가 단 댓글인지
+            boolean isLikedByUser // 현재 로그인된 회원이 좋아요를 누른 댓글인지
     ) {
-        public static CommentResponseWithBoard of(Comment comment) {
+        public static CommentResponseWithBoard of(Comment comment, Long currentUserId) {
             User user = comment.getUser();
             Image userImage = user.getUserImage();
+
+            boolean isLikedByUser = comment.getLikeList().stream()
+                    .anyMatch(like -> like.getUser().getId().equals(currentUserId));
 
             return CommentResponseWithBoard.builder()
                     .commentId(comment.getId())
@@ -49,6 +53,7 @@ public class CommentDto {
                     .commentCount(comment.getCommentCount())
                     .createAt(comment.getCreatedAt())
                     .checkWriter(comment.isCheckWriter())
+                    .isLikedByUser(isLikedByUser)
                     .build();
         }
     }

--- a/src/main/java/com/Sucat/domain/comment/service/CommentService.java
+++ b/src/main/java/com/Sucat/domain/comment/service/CommentService.java
@@ -37,12 +37,17 @@ public class CommentService {
     public void write(Long boardId, HttpServletRequest request, CommentPostRequest commentPostDTO) {
         Board board = boardService.findBoardById(boardId);
         User user = userService.getUserInfo(request);
+        boolean checkWriter = false;
+        if (board.getUser().equals(user)) {
+            checkWriter = true;
+        }
         String content = commentPostDTO.content();
 
         Comment comment = Comment.builder()
                 .content(content)
                 .board(board)
                 .user(user)
+                .checkWriter(checkWriter)
                 .build();
 
         commentRepository.save(comment);

--- a/src/main/java/com/Sucat/domain/like/controller/BoardLikeController.java
+++ b/src/main/java/com/Sucat/domain/like/controller/BoardLikeController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boards/like")
+@RequestMapping("/api/v1/boards/like")
 public class BoardLikeController {
     private final BoardLikeService boardLikeService;
 

--- a/src/main/java/com/Sucat/domain/like/controller/BoardLikeController.java
+++ b/src/main/java/com/Sucat/domain/like/controller/BoardLikeController.java
@@ -1,0 +1,32 @@
+package com.Sucat.domain.like.controller;
+
+import com.Sucat.domain.like.service.BoardLikeService;
+import com.Sucat.global.common.code.SuccessCode;
+import com.Sucat.global.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/boards/like")
+public class BoardLikeController {
+    private final BoardLikeService boardLikeService;
+
+    /* 게시물 좋아요/취소하기 */
+    @PostMapping("/{boardId}")
+    public ResponseEntity<ApiResponse<Object>> like(
+            @PathVariable Long boardId,
+            HttpServletRequest request
+    ) {
+        boardLikeService.like(boardId, request);
+
+        return ApiResponse.onSuccess(SuccessCode._OK);
+    }
+}

--- a/src/main/java/com/Sucat/domain/like/controller/CommentLikeController.java
+++ b/src/main/java/com/Sucat/domain/like/controller/CommentLikeController.java
@@ -1,0 +1,32 @@
+package com.Sucat.domain.like.controller;
+
+import com.Sucat.domain.like.service.CommentLikeService;
+import com.Sucat.global.common.code.SuccessCode;
+import com.Sucat.global.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/boards/like")
+public class CommentLikeController {
+    private final CommentLikeService commentLikeService;
+
+    /* 댓글 좋아요/취소하기 */
+    @PostMapping("/{commentId}")
+    public ResponseEntity<ApiResponse<Object>> like(
+            @PathVariable Long commentId,
+            HttpServletRequest request
+    ) {
+        commentLikeService.like(commentId, request);
+
+        return ApiResponse.onSuccess(SuccessCode._OK);
+    }
+}

--- a/src/main/java/com/Sucat/domain/like/controller/CommentLikeController.java
+++ b/src/main/java/com/Sucat/domain/like/controller/CommentLikeController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/boards/like")
+@RequestMapping("/api/v1/comments/like")
 public class CommentLikeController {
     private final CommentLikeService commentLikeService;
 

--- a/src/main/java/com/Sucat/domain/like/model/BoardLike.java
+++ b/src/main/java/com/Sucat/domain/like/model/BoardLike.java
@@ -1,4 +1,4 @@
-package com.Sucat.domain.favorite.model;
+package com.Sucat.domain.like.model;
 
 import com.Sucat.global.common.dao.BaseEntity;
 import com.Sucat.domain.board.model.Board;
@@ -15,10 +15,10 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Favorite extends BaseEntity {
+public class BoardLike extends BaseEntity {
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "favorite_id")
+    @Column(name = "board_like_id")
     private Long id;
 
     @ManyToOne(fetch = LAZY)
@@ -31,7 +31,7 @@ public class Favorite extends BaseEntity {
 
     /*연관관계 메서드*/
     @Builder
-    public Favorite(User user, Board board) {
+    public BoardLike(User user, Board board) {
         this.user = user;
         this.board = board;
     }

--- a/src/main/java/com/Sucat/domain/like/model/CommentLike.java
+++ b/src/main/java/com/Sucat/domain/like/model/CommentLike.java
@@ -26,7 +26,7 @@ public class CommentLike extends BaseEntity {
     private User user;
 
     @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "board_id") // Board 삭제 -> Comment 자동 삭제 -> CommentLike 삭제, 사용자
+    @JoinColumn(name = "comment_id") // Board 삭제 -> Comment 자동 삭제 -> CommentLike 삭제, 사용자
     private Comment comment;
 
     /*연관관계 메서드*/

--- a/src/main/java/com/Sucat/domain/like/model/CommentLike.java
+++ b/src/main/java/com/Sucat/domain/like/model/CommentLike.java
@@ -1,0 +1,38 @@
+package com.Sucat.domain.like.model;
+
+import com.Sucat.domain.comment.domain.Comment;
+import com.Sucat.domain.user.model.User;
+import com.Sucat.global.common.dao.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "comment_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "board_id") // Board 삭제 -> Comment 자동 삭제 -> CommentLike 삭제, 사용자
+    private Comment comment;
+
+    /*연관관계 메서드*/
+    @Builder
+    public CommentLike(User user, Comment comment) {
+        this.user = user;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/Sucat/domain/like/repository/BoardLikeRepository.java
+++ b/src/main/java/com/Sucat/domain/like/repository/BoardLikeRepository.java
@@ -1,0 +1,10 @@
+package com.Sucat.domain.like.repository;
+
+import com.Sucat.domain.board.model.Board;
+import com.Sucat.domain.like.model.BoardLike;
+import com.Sucat.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
+    BoardLike findByUserAndBoard(User user, Board board);
+}

--- a/src/main/java/com/Sucat/domain/like/repository/CommentLikeRepository.java
+++ b/src/main/java/com/Sucat/domain/like/repository/CommentLikeRepository.java
@@ -1,0 +1,10 @@
+package com.Sucat.domain.like.repository;
+
+import com.Sucat.domain.comment.domain.Comment;
+import com.Sucat.domain.like.model.CommentLike;
+import com.Sucat.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    CommentLike findByUserAndComment(User user, Comment comment);
+}

--- a/src/main/java/com/Sucat/domain/like/service/BoardLikeService.java
+++ b/src/main/java/com/Sucat/domain/like/service/BoardLikeService.java
@@ -4,7 +4,6 @@ import com.Sucat.domain.board.model.Board;
 import com.Sucat.domain.board.service.BoardService;
 import com.Sucat.domain.like.model.BoardLike;
 import com.Sucat.domain.like.repository.BoardLikeRepository;
-import com.Sucat.domain.scrap.model.Scrap;
 import com.Sucat.domain.user.model.User;
 import com.Sucat.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,11 +36,6 @@ public class BoardLikeService {
         } else {
             // 좋아요 누르지 않은 경우: 좋아요 추가
             log.info("식별자(boardId): {}, 게시글에 좋아요를 누릅니다.", boardId);
-            Scrap scrap = Scrap.builder()
-                    .user(user)
-                    .board(board)
-                    .build();
-
             BoardLike boardLike = BoardLike.builder()
                     .user(user)
                     .board(board)

--- a/src/main/java/com/Sucat/domain/like/service/BoardLikeService.java
+++ b/src/main/java/com/Sucat/domain/like/service/BoardLikeService.java
@@ -1,0 +1,53 @@
+package com.Sucat.domain.like.service;
+
+import com.Sucat.domain.board.model.Board;
+import com.Sucat.domain.board.service.BoardService;
+import com.Sucat.domain.like.model.BoardLike;
+import com.Sucat.domain.like.repository.BoardLikeRepository;
+import com.Sucat.domain.scrap.model.Scrap;
+import com.Sucat.domain.user.model.User;
+import com.Sucat.domain.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BoardLikeService {
+    private final BoardLikeRepository boardLikeRepository;
+    private final UserService userService;
+    private final BoardService boardService;
+
+    @Transactional
+    public void like(Long boardId, HttpServletRequest request) {
+        User user = userService.getUserInfo(request);
+        Board board = boardService.findBoardById(boardId);
+
+        // 이미 좋아요 누른 경우 확인
+        BoardLike existingBoardLike = boardLikeRepository.findByUserAndBoard(user, board);
+
+        if (existingBoardLike != null) {
+            // 이미 좋아요 누른 경우: 좋아요 취소 (삭제)
+            log.info("식별자(boardId): {}, 이미 좋아요 한 게시물 -> 좋아요 삭제", boardId);
+            boardLikeRepository.delete(existingBoardLike);
+            board.decrementLikeCount();
+        } else {
+            // 좋아요 누르지 않은 경우: 좋아요 추가
+            log.info("식별자(boardId): {}, 게시글에 좋아요를 누릅니다.", boardId);
+            Scrap scrap = Scrap.builder()
+                    .user(user)
+                    .board(board)
+                    .build();
+
+            BoardLike boardLike = BoardLike.builder()
+                    .user(user)
+                    .board(board)
+                    .build();
+            boardLikeRepository.save(boardLike);
+            board.addLike(boardLike);
+        }
+    }
+}

--- a/src/main/java/com/Sucat/domain/like/service/CommentLikeService.java
+++ b/src/main/java/com/Sucat/domain/like/service/CommentLikeService.java
@@ -1,0 +1,48 @@
+package com.Sucat.domain.like.service;
+
+import com.Sucat.domain.comment.domain.Comment;
+import com.Sucat.domain.comment.service.CommentService;
+import com.Sucat.domain.like.model.CommentLike;
+import com.Sucat.domain.like.repository.CommentLikeRepository;
+import com.Sucat.domain.user.model.User;
+import com.Sucat.domain.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+    private final CommentLikeRepository commentLikeRepository;
+    private final UserService userService;
+    private final CommentService commentService;
+
+    @Transactional
+    public void like(Long commendId, HttpServletRequest request) {
+        User user = userService.getUserInfo(request);
+        Comment comment = commentService.findById(commendId);
+
+        // 이미 좋아요 누른 경우 확인
+        CommentLike existingCommentLike = commentLikeRepository.findByUserAndComment(user, comment);
+
+        if (existingCommentLike != null) {
+            // 이미 좋아요 누른 경우: 좋아요 취소 (삭제)
+            log.info("식별자(commentId): {}, 이미 좋아요 한 게시물 -> 좋아요 삭제", commendId);
+            commentLikeRepository.delete(existingCommentLike);
+            comment.decrementLikeCount();
+        } else {
+            // 좋아요 누르지 않은 경우: 좋아요 추가
+            log.info("식별자(commentId): {}, 게시글에 좋아요를 누릅니다.", commendId);
+
+            CommentLike commentLike = CommentLike.builder()
+                    .user(user)
+                    .comment(comment)
+                    .build();
+            commentLikeRepository.save(commentLike);
+            comment.addLike(commentLike);
+        }
+    }
+}

--- a/src/main/java/com/Sucat/domain/user/model/User.java
+++ b/src/main/java/com/Sucat/domain/user/model/User.java
@@ -88,7 +88,6 @@ public class User extends BaseEntity {
     public void addScrap(Scrap scrap) {
         this.scrapList.add(scrap);
     }
-
     // 필요하다면 Scrap 리스트에서 제거하는 메서드
     public void removeScrap(Scrap scrap) {
         scrapList.remove(scrap);


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 기능 수정
- [x] 코드 리팩토링
- [x] 버그 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더의 변경
- [ ] 주석 혹은 문서 수정

### PR 요약
**게시글 관련 기능 개발**
- 게시물 작성자가 자신의 게시물에 댓글을 작성한 경우를 체크하는 boolean 속성 추가
- 현재 로그인한 사용자가 좋아요, 스크랩 한 게시물인지 체크하는 boolean 속성 추가
- 현재 사용자가 좋아요 누른 댓글인지 체크하는 boolean 속성 추가

**기능 개발**
- 게시물 좋아요 기능 개발
  - 게시물 좋아요를 누른 상태로 다시 좋아요를 누르면 좋아요가 취소되도록 하나의 API에 좋아요 누르기/취소하기 기능 개발
- 댓글 좋아요 기능 개발
  - 댓글 좋아요를 누른 상태로 다시 좋아요를 누르면 좋아요가 취소되도록 하나의 API에 좋아요 누르기/취소하기 기능 개발

**오류 수정**
- CommentController의 RequestMapping API 경로가 BoardLikeController의 RequestMapping API 경로와 똑같은 경로도 되어 있던 문제 발견 -> 수정
- Comment, CommentLike 연관관계 설정 중 name, mappedBy 명이 잘못되어있던 문제 발결 -> 수정

### 변경 사항
좋아요 기능 개발을 위한 Entity 추가
- 게시물 좋아요: BoardLike
- 댓글 좋아요: CommentLike

Cascade를 활용한 자동 삭제 흐름 구현을 위한 연관관계 설정
- Board <-> BoardLike 간의 양방향 연관관계 설정
  - Board -> BoardLike 연관관계 설정을 `CascadeType.REMOVE`, `orphanRemoval = true`로 설정해서 Board 삭제 시 BoardLike 자동 삭제
- Comment <-> CommentLike 간의 양방향 연관관계 설정
  - Comment -> CommentLike 연관관계 설정을 `CascadeType.REMOVE`, `orphanRemoval = true`로 설정해서 Comment 삭제 시 CommentLike 자동 삭제

### 추가로 알리고 싶은 내용
이번 좋아요 기능 개발을 하면서 연관관계 설정이 넓은 범위로 되어있는 문제를 발견했습니다.
ex) 무분별한 CascadeType.ALL 사용

추후 개발이 끝난 후 이와 같은 설정을 상황와 필요에 따라 수정할 필요가 있습니다.

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 본인을 Assign해주시고, 본인을 제외한 백엔드 개발자를 Reviewer로 지정해주세요.
- [x] 라벨 체크해주세요.
